### PR TITLE
Enabled Tashkeel support in Arabic

### DIFF
--- a/Assets/Polyglot/Scripts/Localization.cs
+++ b/Assets/Polyglot/Scripts/Localization.cs
@@ -384,7 +384,7 @@ namespace Polyglot
     #if ARABSUPPORT_ENABLED
                 if (selected == (int) Language.Arabic)
                 {
-                    return ArabicSupport.ArabicFixer.Fix(currentString);
+                    return ArabicSupport.ArabicFixer.Fix(currentString, true, false);
                 }
     #endif
                 


### PR DESCRIPTION
Enabled Tashkeel support in Arabic. This is required for a few select entries in Arabic. Changed one line only.

The second booleon in ArabicFixer.Fix() is "showTashkeel" which are the the vowel marks in Arabic. This is disabled by default, however, I need it to be enabled because I have used that feature in a few entries. My tests show everything works fine when it's enabled.