### PR TITLE
start end parsing equal comparison

### DIFF
--- a/Assets/Polyglot/Scripts/LocalizationImporter.cs
+++ b/Assets/Polyglot/Scripts/LocalizationImporter.cs
@@ -140,12 +140,7 @@ namespace Polyglot
                     if (key == "Polyglot" || key == "PolyMaster" || key == "BEGIN")
                     {
                         canBegin = true;
-                        continue;
                     }
-                }
-
-                if (!canBegin)
-                {
                     continue;
                 }
 

--- a/Assets/Polyglot/Scripts/LocalizationImporter.cs
+++ b/Assets/Polyglot/Scripts/LocalizationImporter.cs
@@ -137,7 +137,7 @@ namespace Polyglot
                 
                 if (!canBegin)
                 {
-                    if (key.StartsWith("Polyglot") || key.StartsWith("PolyMaster") || key.StartsWith("BEGIN"))
+                    if (key == "Polyglot" || key == "PolyMaster" || key == "BEGIN")
                     {
                         canBegin = true;
                         continue;
@@ -149,7 +149,7 @@ namespace Polyglot
                     continue;
                 }
 
-                if (key.StartsWith("END"))
+                if (key == "END")
                 {
                     break;
                 }


### PR DESCRIPTION
See Issue #16 

Start and end of parsing a CSV/TSV file is triggered with equal comparison instead of StartsWith to avoid problems with keywords that start with "END"