### PR TITLE
Download on start bug fix; Save downloaded text and load the text when app startup next time.

### DIFF
--- a/Assets/Polyglot/Scripts/LocalizationImporter.cs
+++ b/Assets/Polyglot/Scripts/LocalizationImporter.cs
@@ -97,7 +97,7 @@ namespace Polyglot
                 var preferenceKey = GetCacheKey(settings.PolyglotDocument);
                 if (PlayerPrefs.HasKey(preferenceKey))
                 {
-                    Debug.Log($"ImportFromCache PolyglotDocument");
+//                    Debug.Log($"ImportFromCache PolyglotDocument");
                     ImportTextFile(PlayerPrefs.GetString(preferenceKey), settings.PolyglotDocument.Format);
                 }
             }
@@ -108,7 +108,7 @@ namespace Polyglot
                 var preferenceKey = GetCacheKey(settings.CustomDocument);
                 if (PlayerPrefs.HasKey(preferenceKey))
                 {
-                    Debug.Log($"ImportFromCache CustomDocument");
+//                    Debug.Log($"ImportFromCache CustomDocument");
                     ImportTextFile(PlayerPrefs.GetString(preferenceKey), settings.CustomDocument.Format);
                 }
             }
@@ -123,7 +123,7 @@ namespace Polyglot
         {
             if (!string.IsNullOrEmpty(text))
             {
-                Debug.Log($"SaveTextToCache {document.DocsId}");
+//                Debug.Log($"SaveTextToCache {document.DocsId}");
                 PlayerPrefs.SetString(GetCacheKey(document), text);
             }
         }
@@ -203,7 +203,7 @@ namespace Polyglot
 
                 if (languageStrings.ContainsKey(key))
                 {
-                    Debug.Log("The key '" + key + "' already exist, but is now overwritten");
+//                    Debug.Log("The key '" + key + "' already exist, but is now overwritten");
                     languageStrings[key] = row;
                     continue;
                 }

--- a/Assets/Polyglot/Scripts/SaveLanguagePreference.cs
+++ b/Assets/Polyglot/Scripts/SaveLanguagePreference.cs
@@ -14,6 +14,11 @@ namespace Polyglot
 #if UNITY_5
         [UsedImplicitly]
 #endif
+        private void Awake()
+        {
+            LocalizationImporter.ImportFromGoogle(Localization.Instance, this);
+            DontDestroyOnLoad(gameObject);
+        }
         public void Start()
         {
             Localization.Instance.SelectedLanguage = (Language) PlayerPrefs.GetInt(preferenceKey);


### PR DESCRIPTION
1. download docs should run on a coroutine;
2. if condition for download PolyglotDocument is wrong;
3. save the downloaded text;
4. load the last downloaded text when app startup;
5. make the SaveLanguagePreference DontDestroyOnLoad and import from google in Awake, so all that users need to do is just drag this prefab into their scenes, and have no side effect when replace scenes in runtime.