### PR TITLE
Added support for changing font per language

### DIFF
--- a/Assets/Polyglot/Editor/FontOverrideDrawer.cs
+++ b/Assets/Polyglot/Editor/FontOverrideDrawer.cs
@@ -1,0 +1,40 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace Polyglot
+{
+	[CustomPropertyDrawer(typeof(FontOverride), true)]
+	public sealed class FontOverrideDrawer : PropertyDrawer
+	{
+#if UNITY_2017_3_OR_NEWER
+		public override bool CanCacheInspectorGUI(SerializedProperty property)
+		{
+			// Cache lead to problems on the layout.
+			return false;
+		}
+#endif
+		
+		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+		{
+			EditorGUI.BeginProperty(position, label, property);
+
+			Rect left, right;
+			left = right = position;
+			left.width = EditorGUIUtility.labelWidth;
+			right.xMin += left.width;
+			left = EditorGUI.IndentedRect(left);
+
+			int oldIndentLevel = EditorGUI.indentLevel;
+			EditorGUI.indentLevel = 0;
+			
+			var languageProperty = property.FindPropertyRelative("language");
+			var fontProperty = property.FindPropertyRelative("font");
+			EditorGUI.PropertyField(left, languageProperty, GUIContent.none, true);
+			EditorGUI.PropertyField(right, fontProperty, GUIContent.none, true);
+
+			EditorGUI.indentLevel = oldIndentLevel;
+
+			EditorGUI.EndProperty();
+		}
+	}
+}

--- a/Assets/Polyglot/Editor/FontOverrideDrawer.cs.meta
+++ b/Assets/Polyglot/Editor/FontOverrideDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e7664eea5617a4b62ae39ecf3e5ed723
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Polyglot/Scripts/Localization.cs
+++ b/Assets/Polyglot/Scripts/Localization.cs
@@ -7,6 +7,20 @@ using UnityEngine.Events;
 
 namespace Polyglot
 {
+    [System.Serializable]
+    public struct FontOverride
+    {
+        public Language language;
+        public Font font;
+    }
+
+    [System.Serializable]
+    struct FontOverrideSet
+    {
+        public Font referenceFont;
+        public List<FontOverride> overrides;
+    }
+
     [CreateAssetMenu(fileName = "Localization.asset", menuName = "Polyglot Localization")]
     public class Localization : ScriptableObject
     {
@@ -75,7 +89,12 @@ namespace Polyglot
         [Tooltip("If we cant find the string for the selected language we fall back to this language.")]
         [SerializeField]
         private Language fallbackLanguage = Language.English;
-        
+
+        [Header("Language Font Overrides")]
+        [Tooltip("Fonts that should be replaced by other fonts on a per-language basis.\nRelevant for Chinese/Japanese/Korean.\nLanguages not specified will keep the reference font.")]
+        [SerializeField]
+        private List<FontOverrideSet> fontOverrides;
+
 #region Arabic Support
 #if ARABSUPPORT_ENABLED
         [Header("Arabic Support")]
@@ -338,6 +357,28 @@ namespace Polyglot
         public void RemoveOnLocalizeEvent(ILocalize localize)
         {
             Localize.RemoveListener(localize.OnLocalize);
+        }
+
+        public static Font GetFont(Font referenceFont)
+        {
+            return GetFont(referenceFont, Instance.selectedLanguage);
+        }
+
+        public static Font GetFont(Font referenceFont, Language language)
+        {
+            foreach (var overrideSet in Instance.fontOverrides)
+            {
+                if (referenceFont == overrideSet.referenceFont)
+                {
+                    foreach (var fontOverride in overrideSet.overrides)
+                    {
+                        if (fontOverride.language == language)
+                            return fontOverride.font;
+                    }
+                    return referenceFont;
+                }
+            }
+            return referenceFont;
         }
 
         /// <summary>

--- a/Assets/Polyglot/Scripts/LocalizedFont.cs
+++ b/Assets/Polyglot/Scripts/LocalizedFont.cs
@@ -1,0 +1,66 @@
+﻿#if UNITY_5 || UNITY_2017_1_OR_NEWER
+using JetBrains.Annotations;
+#endif
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Polyglot
+{
+    [AddComponentMenu("UI/Localized Font")]
+    [RequireComponent(typeof(Text))]
+    public class LocalizedFont : MonoBehaviour, ILocalize
+    {
+        [Tooltip ("The text component to localize")]
+        [SerializeField]
+        private Text text;
+
+        private bool initializedReferenceFont;
+        private Font referenceFont;
+
+#if UNITY_5 || UNITY_2017_1_OR_NEWER
+        [UsedImplicitly]
+#endif
+        public void Reset ()
+        {
+            text = GetComponent<Text> ();
+        }
+
+#if UNITY_5 || UNITY_2017_1_OR_NEWER
+        [UsedImplicitly]
+#endif
+        public void OnEnable ()
+        {
+            Localization.Instance.AddOnLocalizeEvent(this);
+        }
+
+        public void OnDisable ()
+        {
+            Localization.Instance.RemoveOnLocalizeEvent(this);
+        }
+
+        public void OnLocalize ()
+        {
+            if (!Application.isPlaying)
+                return;
+
+            if (text == null)
+            {
+                Debug.LogWarning ("Missing Text Component on " + gameObject, gameObject);
+                return;
+            }
+
+            if (!initializedReferenceFont)
+            {
+                referenceFont = text.font;
+                initializedReferenceFont = true;
+            }
+
+            text.font = Localization.GetFont (referenceFont);
+        }
+
+        public void SetLanguage (Language language)
+        {
+            text.font = Localization.GetFont (referenceFont, language);
+        }
+    }
+}

--- a/Assets/Polyglot/Scripts/LocalizedFont.cs.meta
+++ b/Assets/Polyglot/Scripts/LocalizedFont.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 49ab24ea9501543808cd6547e3e4503c
+timeCreated: 1441393383
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Polyglot/Scripts/LocalizedTextComponent.cs
+++ b/Assets/Polyglot/Scripts/LocalizedTextComponent.cs
@@ -61,6 +61,11 @@ namespace Polyglot
             Localization.Instance.AddOnLocalizeEvent(this);
         }
 
+        public void OnDisable()
+        {
+            Localization.Instance.RemoveOnLocalizeEvent(this);
+        }
+
         protected abstract void SetText(T component, string value);
 
         protected abstract void UpdateAlignment(T component, LanguageDirection direction);


### PR DESCRIPTION
Chinese, Japanese and Korean all use Han characters but some characters are by convention displayed differently per language. See https://en.wikipedia.org/wiki/Han_unification#Examples_of_language-dependent_glyphs . This necessitates using a separate font for each of them.

This PR adds a LocalizedFont component which can be added to GameObjects with Text components in order to automatically switch the font based on current language. It has no properties apart from the auto-populated Text property which is a reference to the Text component.

The font overrides are specified in the Localization asset.
<img width="327" alt="LanguageFontOverrides" src="https://user-images.githubusercontent.com/6685642/130461191-4e05df78-4de8-4d0c-a8e7-95315b5f453b.png">